### PR TITLE
[fix] 一時ファイルを gitignore に入れているため削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,3 @@ yarn-debug.log*
 
 # Ignore .env
 .env
-
-# Ignore swap file
-*.swp


### PR DESCRIPTION
`*.swp` は一時ファイルなので、 `.gitignore` ではなく、 `excludesfile` での設定が良い  